### PR TITLE
Change accelerator indicator styling

### DIFF
--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -72,9 +72,11 @@ a.type {
     /* simulate a keyboard key effect */
     font-family: monospace;
     font-size: 10px;
-    padding: 2px;
-    border: outset lightgray;
-    border-width: 7px 6px;
+    padding: 1px 3px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    box-shadow: 0 1px #999;
+    background: #f5f5f5;
     margin-left: 10px;
 }
 


### PR DESCRIPTION
This PR changes the styling of the `<kbd>` elements in the sidebar to be a little less aggressive. The new styling is inspired by the one used on github ([example](https://github.com/devtools-html/Gecko-Profiler-Addon/#usage)).

Screenshot before / after:

<img width="557" alt="screen shot 2018-09-26 at 6 43 48 pm" src="https://user-images.githubusercontent.com/961291/46113389-272be280-c1bc-11e8-935b-221424c598f8.png">

r? @staktrace